### PR TITLE
drawer-close attribute and default background color

### DIFF
--- a/ionic.contrib.drawer.css
+++ b/ionic.contrib.drawer.css
@@ -4,6 +4,7 @@ drawer {
   width: 270px;
   height: 100%;
   z-index: 100;
+  background: #ffffff;
 }
 
 drawer.animate {

--- a/ionic.contrib.drawer.js
+++ b/ionic.contrib.drawer.js
@@ -174,4 +174,16 @@ angular.module('ionic.contrib.drawer', ['ionic'])
   }
 }]);
 
+.directive('drawerClose', ['$rootScope', function($rootScope) {
+  return {
+    restrict: 'A',
+    link: function($scope, $element) {
+      $element.bind('click', function() {
+        var drawerCtrl = $element.inheritedData('$drawerController');
+        drawerCtrl.close();
+      }
+    }
+  }
+}]);
+
 })();

--- a/ionic.contrib.drawer.js
+++ b/ionic.contrib.drawer.js
@@ -181,7 +181,7 @@ angular.module('ionic.contrib.drawer', ['ionic'])
       $element.bind('click', function() {
         var drawerCtrl = $element.inheritedData('$drawerController');
         drawerCtrl.close();
-      }
+      });
     }
   }
 }]);


### PR DESCRIPTION
Added ability to add drawer-close to a link within a drawer which will have the same functionality as menu-close for ion-side-menu.

Also added a default background color of #ffffff to the CSS because it was defaulting to transparent and was showing the content behind it.
