### PR TITLE
Update ionic.contrib.drawer.js

### DIFF
--- a/ionic.contrib.drawer.js
+++ b/ionic.contrib.drawer.js
@@ -172,7 +172,7 @@ angular.module('ionic.contrib.drawer', ['ionic'])
       };
     }
   }
-}]);
+}])
 
 .directive('drawerClose', ['$rootScope', function($rootScope) {
   return {


### PR DESCRIPTION
Removed semi-colon @ line:175 to prevent 'unexpected token error' when including the drawer dependency.
