### PR TITLE
one semicolon too much & toggle & autoclose

### DIFF
--- a/ionic.contrib.drawer.js
+++ b/ionic.contrib.drawer.js
@@ -172,7 +172,7 @@ angular.module('ionic.contrib.drawer', ['ionic'])
       };
     }
   }
-}]);
+}])
 
 .directive('drawerClose', ['$rootScope', function($rootScope) {
   return {


### PR DESCRIPTION
- Fix semicolon
- Toggle functionality
- Close when click out of drawer (configurable via the 'autoClose' attribute on the drawer element) 
